### PR TITLE
Fixed a typo in name menu

### DIFF
--- a/src/entity/name.ts
+++ b/src/entity/name.ts
@@ -9,7 +9,7 @@ export class Name implements FakerEntity {
     return [
       'firstName',
       'lastName',
-      'findName',
+      'fullName',
       'jobTitle',
       'prefix',
       'suffix',


### PR DESCRIPTION
I renamed "findname" to "fullname" in the name entity menu so it's more descriptive